### PR TITLE
Use relative path for dxr.config

### DIFF
--- a/dxr/plugins/rust/__init__.py
+++ b/dxr/plugins/rust/__init__.py
@@ -12,7 +12,7 @@ bugs because Python will not check the type of things, but does distinguish betw
     Rust NodeIds/DefIds to internal ids)
 * Helper methods might take args which may or may not have been int-ified :-(
 
-This will all go away when we convery to using JSON instead of CSV for the data
+This will all go away when we convert to using JSON instead of CSV for the data
 interchange format.
 
 Line and column numbers are stored as strings though.

--- a/dxr/plugins/rust/tests/test_mods/dxr.config
+++ b/dxr/plugins/rust/tests/test_mods/dxr.config
@@ -5,7 +5,7 @@ es_index            = dxr_{format}_{tree}_{unique}
 es_alias            = dxr_{format}_{tree}
 
 [code]
-source_folder=/home/ncameron/dxr/src2/dxr/plugins/rust/tests/test_mods/code
-object_folder=/home/ncameron/dxr/src2/dxr/plugins/rust/tests/test_mods/code
+source_folder=code
+object_folder=code
 build_command=make clean; make -j $jobs
 

--- a/dxr/plugins/rust/tests/test_traits/dxr.config
+++ b/dxr/plugins/rust/tests/test_traits/dxr.config
@@ -5,7 +5,7 @@ es_index            = dxr_{format}_{tree}_{unique}
 es_alias            = dxr_{format}_{tree}
 
 [code]
-source_folder=/home/ncameron/dxr/src2/dxr/plugins/rust/tests/test_traits/code
-object_folder=/home/ncameron/dxr/src2/dxr/plugins/rust/tests/test_traits/code
+source_folder=code
+object_folder=code
 build_command=make clean; make -j $jobs
 

--- a/dxr/plugins/rust/tests/test_vars/dxr.config
+++ b/dxr/plugins/rust/tests/test_vars/dxr.config
@@ -5,7 +5,7 @@ es_index            = dxr_{format}_{tree}_{unique}
 es_alias            = dxr_{format}_{tree}
 
 [code]
-source_folder=/home/ncameron/dxr/src2/dxr/plugins/rust/tests/test_vars/code
-object_folder=/home/ncameron/dxr/src2/dxr/plugins/rust/tests/test_vars/code
+source_folder=code
+object_folder=code
 build_command=make clean; make -j $jobs
 


### PR DESCRIPTION
Some of the tests already used relative paths; I went ahead and inserted it for the others. Also fixed a typo at the top of the plugin file.
